### PR TITLE
CONFIG_NET_ICMP_SOCKET needs of NET_READAHEAD

### DIFF
--- a/mm/iob/Kconfig
+++ b/mm/iob/Kconfig
@@ -42,11 +42,6 @@ config IOB_NCHAINS
 		that can be "in-flight" at any give time.  The default value of
 		zero disables this features.
 
-		These generic I/O buffer chain containers are not currently used
-		by any logic in NuttX.  That is because their other other specialized
-		I/O buffer chain containers that also carry a payload of usage
-		specific information.
-
 config IOB_THROTTLE
 	int "I/O buffer throttle value"
 	default 0 if !NET_WRITE_BUFFERS || !NET_READAHEAD

--- a/net/icmp/Kconfig
+++ b/net/icmp/Kconfig
@@ -24,8 +24,9 @@ if NET_ICMP && !NET_ICMP_NO_STACK
 
 config NET_ICMP_SOCKET
 	bool "IPPROTO_ICMP socket support"
-	default n
+	default y
 	select MM_IOB
+	select NET_READAHEAD
 	---help---
 		Enable support for IPPROTO_ICMP sockets.  These sockets are needed
 		for application level support for sending ECHO (ping) requests and


### PR DESCRIPTION
If NET_READAHEAD is not selected, struct iob_queue_s is not defined in iob.h and compilation fails at netlib_setifstatus.c

## Summary

## Impact
Improves  menuconfig avoiding a defective config

## Testing

